### PR TITLE
fix: normalize windows path handling

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,13 @@
-import { join, resolve } from "node:path";
+import { join, posix, resolve } from "node:path";
 import Elysia from "elysia";
+
+const normalizeSeparators = (value: string) => value.replace(/\\/g, "/");
+
+export const toRoutePath = (filePath: string, prefix = "/") =>
+	posix
+		.join(normalizeSeparators(prefix), normalizeSeparators(filePath))
+		.replace(/\/index\.ts$|\.ts$/, "")
+		.replace(/\[([^\]]+)\]/g, ":$1");
 
 /**
  * Autoload routes from a directory.
@@ -10,7 +18,7 @@ export async function autoload<T = Elysia>(options: {
 	/**
 	 * The directory to autoload routes from.
 	 */
-	dir: string;
+	dir?: string;
 	/**
 	 * The prefix to apply to all routes.
 	 */
@@ -24,15 +32,17 @@ export async function autoload<T = Elysia>(options: {
 	 */
 	typegen?: boolean | string;
 }): Promise<T> {
+	const dir = options.dir ?? "./routes";
+
 	if (options.typegen) {
 		const { generateTypes } = await import("./typegen");
 		const output =
 			typeof options.typegen === "string"
 				? options.typegen
-				: join(options.dir, "../routes.d.ts");
+				: join(dir, "../routes.d.ts");
 
 		await generateTypes({
-			dir: options.dir,
+			dir,
 			prefix: options.prefix,
 			output,
 		});
@@ -40,23 +50,18 @@ export async function autoload<T = Elysia>(options: {
 
 	const app = new Elysia({
 		name: "autoload",
-		seed: options.dir,
+		seed: dir,
 	});
 
-	for await (const path of new Bun.Glob("**/*.ts").scan({ cwd: options.dir })) {
+	for await (const path of new Bun.Glob("**/*.ts").scan({ cwd: dir })) {
 		if (path.endsWith(".d.ts")) continue;
 
-		const module = await import(resolve(options.dir, path));
+		const module = await import(resolve(dir, path));
 
 		if (typeof module.default !== "function")
 			throw new Error(`autoload: "${path}" must export a function`);
 
-		app.group(
-			join(options.prefix ?? "/", path)
-				.replace(/\/index\.ts$|\.ts$/, "")
-				.replace(/\[([^\]]+)\]/g, ":$1"),
-			module.default,
-		);
+		app.group(toRoutePath(path, options.prefix ?? "/"), module.default);
 	}
 
 	return app as T;

--- a/src/typegen.ts
+++ b/src/typegen.ts
@@ -1,6 +1,28 @@
 import { mkdirSync } from "node:fs";
 import * as p from "node:path";
 
+const normalizeSeparators = (value: string) => value.replace(/\\/g, "/");
+
+export const toTypeImportPath = (output: string, dir: string, file: string) => {
+	let relativeImportPath = p.relative(p.dirname(output), p.join(dir, file));
+	relativeImportPath = normalizeSeparators(relativeImportPath);
+
+	if (!relativeImportPath.startsWith(".")) {
+		relativeImportPath = `./${relativeImportPath}`;
+	}
+
+	return relativeImportPath.substring(
+		0,
+		relativeImportPath.length - p.extname(relativeImportPath).length,
+	);
+};
+
+export const toRouteLiteral = (filePath: string, prefix = "/") =>
+	p.posix
+		.join(normalizeSeparators(prefix), normalizeSeparators(filePath))
+		.replace(/\/index\.ts$|\.ts$/, "")
+		.replace(/\[([^\]]+)\]/g, ":$1");
+
 export async function generateTypes(options: {
 	dir: string;
 	output: string;
@@ -15,30 +37,21 @@ export async function generateTypes(options: {
 	// Sort for stable output
 	files.sort();
 
-	const _outputDir = p.dirname(options.output);
 	const imports: string[] = [];
 	const typeIds: [string, string][] = [];
 
 	files.forEach((file, index) => {
 		const typeId = `Route${index}`;
-		let relativeImportPath = p.relative(
-			p.dirname(options.output),
-			p.join(options.dir, file),
+		const relativeImportPath = toTypeImportPath(
+			options.output,
+			options.dir,
+			file,
 		);
 
-		if (!relativeImportPath.startsWith(".")) {
-			relativeImportPath = `./${relativeImportPath}`;
-		}
-
-		imports.push(
-			`import type ${typeId} from "${relativeImportPath.substring(0, relativeImportPath.length - p.extname(relativeImportPath).length)}";`,
-		);
+		imports.push(`import type ${typeId} from "${relativeImportPath}";`);
 		typeIds.push([
 			typeId,
-			p
-				.join(options.prefix ?? "/", file)
-				.replace(/\/index\.ts$|\.ts$/, "")
-				.replace(/\[([^\]]+)\]/g, ":$1"),
+			toRouteLiteral(file, options.prefix ?? "/"),
 		] as const);
 	});
 

--- a/test/path-normalization.test.ts
+++ b/test/path-normalization.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "bun:test";
+import { toRoutePath } from "../src/index";
+import { toRouteLiteral, toTypeImportPath } from "../src/typegen";
+
+describe("Path normalization - Windows semantics", () => {
+	it("normalizes route paths with Windows separators in autoload", () => {
+		expect(toRoutePath("admin\\settings.ts", "/api")).toBe(
+			"/api/admin/settings",
+		);
+		expect(toRoutePath("admin\\index.ts", "/api")).toBe("/api/admin");
+		expect(toRoutePath("auth\\[provider]\\index.ts", "/api")).toBe(
+			"/api/auth/:provider",
+		);
+	});
+
+	it("normalizes import specifiers for generated types", () => {
+		expect(
+			toTypeImportPath(
+				"example/routes.d.ts",
+				"example/routes",
+				"admin\\settings.ts",
+			),
+		).toBe("./routes/admin/settings");
+		expect(toTypeImportPath("routes.d.ts", "routes", "users.ts")).toBe(
+			"./routes/users",
+		);
+	});
+
+	it("normalizes route literals for generated types", () => {
+		expect(toRouteLiteral("admin\\settings.ts", "/api")).toBe(
+			"/api/admin/settings",
+		);
+		expect(toRouteLiteral("admin\\index.ts", "/api")).toBe("/api/admin");
+		expect(toRouteLiteral("admin\\[section]\\index.ts", "/api")).toBe(
+			"/api/admin/:section",
+		);
+	});
+});


### PR DESCRIPTION
ON windows, elysia-atlas currently has issues with paths due to how paths in windows are largely different from UNIX systems.

This PR addresses this