### PR TITLE
fix: handle optional autoload config

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,24 +14,26 @@ export const toRoutePath = (filePath: string, prefix = "/") =>
  * @param options - Options for autoloading routes.
  * @returns The autoloaded routes.
  */
-export async function autoload<T = Elysia>(options: {
-	/**
-	 * The directory to autoload routes from.
-	 */
-	dir?: string;
-	/**
-	 * The prefix to apply to all routes.
-	 */
-	prefix?: string;
-	/**
-	 * Whether to generate type definitions for the routes.
-	 *
-	 * This can be a boolean or a string representing the output path.
-	 *
-	 * @default false
-	 */
-	typegen?: boolean | string;
-}): Promise<T> {
+export async function autoload<T = Elysia>(
+	options: {
+		/**
+		 * The directory to autoload routes from.
+		 */
+		dir?: string;
+		/**
+		 * The prefix to apply to all routes.
+		 */
+		prefix?: string;
+		/**
+		 * Whether to generate type definitions for the routes.
+		 *
+		 * This can be a boolean or a string representing the output path.
+		 *
+		 * @default false
+		 */
+		typegen?: boolean | string;
+	} = {},
+): Promise<T> {
 	const dir = options.dir ?? "./routes";
 
 	if (options.typegen) {

--- a/src/typegen.ts
+++ b/src/typegen.ts
@@ -56,13 +56,26 @@ export async function generateTypes(options: {
 	});
 
 	mkdirSync(p.dirname(options.output), { recursive: true });
+	const autoloadedImportLine = typeIds.length
+		? `import type { WithBasePath } from "elysia-atlas/types";`
+		: `import type Elysia from "elysia";`;
+
+	const autoloadedRoutesType =
+		typeIds.length === 0
+			? "Elysia"
+			: typeIds
+					.map(
+						([id, path]) => `WithBasePath<ReturnType<typeof ${id}>, "${path}">`,
+					)
+					.join(" & ");
+
 	await Bun.write(
 		options.output,
 		`/* eslint-disable */
 // @ts-nocheck
-import type { WithBasePath } from "elysia-atlas/types";
+${autoloadedImportLine}
 ${imports.join("\n")}
-export type AutoloadedRoutes = ${typeIds.map(([id, path]) => `WithBasePath<ReturnType<typeof ${id}>, "${path}">`).join(" & ")};
+export type AutoloadedRoutes = ${autoloadedRoutesType};
 `,
 	);
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,8 +1,32 @@
 import { describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { Elysia } from "elysia";
 import { autoload } from "../src/index";
+import { generateTypes } from "../src/typegen";
 
 describe("Autoload - Basic", () => {
+	it("should support calling autoload without options", async () => {
+		mkdirSync("./routes", { recursive: true });
+		await Bun.write(
+			"./routes/index.ts",
+			`import { Elysia } from "elysia";
+
+export default (app: Elysia) => app.get("/", () => "default route");
+`,
+		);
+
+		try {
+			const app = new Elysia().use(await autoload());
+			const response = await app.handle(new Request("http://localhost/"));
+			expect(response.status).toBe(200);
+			expect(await response.text()).toBe("default route");
+		} finally {
+			rmSync("./routes", { recursive: true, force: true });
+		}
+	});
+
 	it("should autoload routes from directory", async () => {
 		const app = new Elysia().use(
 			await autoload({
@@ -43,9 +67,7 @@ describe("Autoload - Basic", () => {
 
 describe("Autoload - Complex Routes", () => {
 	it("should handle health endpoint returning JSON", async () => {
-		const app = new Elysia().use(
-			await autoload({ dir: "./example/routes" }),
-		);
+		const app = new Elysia().use(await autoload({ dir: "./example/routes" }));
 
 		const response = await app.handle(new Request("http://localhost/health"));
 		expect(response.status).toBe(200);
@@ -55,9 +77,7 @@ describe("Autoload - Complex Routes", () => {
 	});
 
 	it("should handle GET with query parameters", async () => {
-		const app = new Elysia().use(
-			await autoload({ dir: "./example/routes" }),
-		);
+		const app = new Elysia().use(await autoload({ dir: "./example/routes" }));
 
 		const response = await app.handle(
 			new Request("http://localhost/users?page=2&limit=5"),
@@ -69,9 +89,7 @@ describe("Autoload - Complex Routes", () => {
 	});
 
 	it("should handle POST with body validation", async () => {
-		const app = new Elysia().use(
-			await autoload({ dir: "./example/routes" }),
-		);
+		const app = new Elysia().use(await autoload({ dir: "./example/routes" }));
 
 		const response = await app.handle(
 			new Request("http://localhost/posts", {
@@ -92,9 +110,7 @@ describe("Autoload - Complex Routes", () => {
 	});
 
 	it("should handle PUT with params and body", async () => {
-		const app = new Elysia().use(
-			await autoload({ dir: "./example/routes" }),
-		);
+		const app = new Elysia().use(await autoload({ dir: "./example/routes" }));
 
 		const response = await app.handle(
 			new Request("http://localhost/posts/1", {
@@ -111,9 +127,7 @@ describe("Autoload - Complex Routes", () => {
 	});
 
 	it("should handle DELETE with params", async () => {
-		const app = new Elysia().use(
-			await autoload({ dir: "./example/routes" }),
-		);
+		const app = new Elysia().use(await autoload({ dir: "./example/routes" }));
 
 		const response = await app.handle(
 			new Request("http://localhost/posts/2", {
@@ -126,9 +140,7 @@ describe("Autoload - Complex Routes", () => {
 	});
 
 	it("should handle PATCH with params and body", async () => {
-		const app = new Elysia().use(
-			await autoload({ dir: "./example/routes" }),
-		);
+		const app = new Elysia().use(await autoload({ dir: "./example/routes" }));
 
 		const response = await app.handle(
 			new Request("http://localhost/users/1", {
@@ -145,9 +157,7 @@ describe("Autoload - Complex Routes", () => {
 
 describe("Autoload - Nested Directories", () => {
 	it("should handle 2-level nested routes (auth/sign-in)", async () => {
-		const app = new Elysia().use(
-			await autoload({ dir: "./example/routes" }),
-		);
+		const app = new Elysia().use(await autoload({ dir: "./example/routes" }));
 
 		const response = await app.handle(
 			new Request("http://localhost/auth/sign-in", {
@@ -166,9 +176,7 @@ describe("Autoload - Nested Directories", () => {
 	});
 
 	it("should handle 2-level nested routes (auth/sign-up)", async () => {
-		const app = new Elysia().use(
-			await autoload({ dir: "./example/routes" }),
-		);
+		const app = new Elysia().use(await autoload({ dir: "./example/routes" }));
 
 		const response = await app.handle(
 			new Request("http://localhost/auth/sign-up", {
@@ -190,9 +198,7 @@ describe("Autoload - Nested Directories", () => {
 	});
 
 	it("should handle 2-level nested routes (auth/sign-out)", async () => {
-		const app = new Elysia().use(
-			await autoload({ dir: "./example/routes" }),
-		);
+		const app = new Elysia().use(await autoload({ dir: "./example/routes" }));
 
 		const response = await app.handle(
 			new Request("http://localhost/auth/sign-out", {
@@ -205,9 +211,7 @@ describe("Autoload - Nested Directories", () => {
 	});
 
 	it("should handle 2-level nested routes with multiple sub-routes (auth/session)", async () => {
-		const app = new Elysia().use(
-			await autoload({ dir: "./example/routes" }),
-		);
+		const app = new Elysia().use(await autoload({ dir: "./example/routes" }));
 
 		// Test GET session
 		const sessionRes = await app.handle(
@@ -228,9 +232,7 @@ describe("Autoload - Nested Directories", () => {
 	});
 
 	it("should handle 2-level nested routes with path params (auth/callback)", async () => {
-		const app = new Elysia().use(
-			await autoload({ dir: "./example/routes" }),
-		);
+		const app = new Elysia().use(await autoload({ dir: "./example/routes" }));
 
 		// Test GET callback/:provider
 		const getRes = await app.handle(
@@ -255,9 +257,7 @@ describe("Autoload - Nested Directories", () => {
 	});
 
 	it("should handle 2-level nested routes (auth/verify-email)", async () => {
-		const app = new Elysia().use(
-			await autoload({ dir: "./example/routes" }),
-		);
+		const app = new Elysia().use(await autoload({ dir: "./example/routes" }));
 
 		const response = await app.handle(
 			new Request("http://localhost/auth/verify-email", {
@@ -275,9 +275,7 @@ describe("Autoload - Nested Directories", () => {
 	});
 
 	it("should handle 2-level nested routes (admin/settings)", async () => {
-		const app = new Elysia().use(
-			await autoload({ dir: "./example/routes" }),
-		);
+		const app = new Elysia().use(await autoload({ dir: "./example/routes" }));
 
 		// GET settings
 		const getRes = await app.handle(
@@ -304,9 +302,7 @@ describe("Autoload - Nested Directories", () => {
 	});
 
 	it("should handle 3-level nested routes (admin/analytics/overview)", async () => {
-		const app = new Elysia().use(
-			await autoload({ dir: "./example/routes" }),
-		);
+		const app = new Elysia().use(await autoload({ dir: "./example/routes" }));
 
 		const response = await app.handle(
 			new Request("http://localhost/admin/analytics/overview?period=30d"),
@@ -359,9 +355,7 @@ describe("Autoload - With Prefix", () => {
 			prefix: "/api",
 		});
 
-		const app = new Elysia()
-			.get("/root", () => "root")
-			.use(routes);
+		const app = new Elysia().get("/root", () => "root").use(routes);
 
 		// Root app route
 		const rootRes = await app.handle(new Request("http://localhost/root"));
@@ -428,5 +422,19 @@ describe("Autoload - Typegen", () => {
 		expect(content).toContain('"/api/users"');
 		expect(content).toContain('"/api/auth/sign-in"');
 		expect(content).toContain('"/api/admin/analytics/overview"');
+	});
+
+	it("should generate valid type definitions for an empty routes directory", async () => {
+		const emptyDir = mkdtempSync(join(tmpdir(), "atlas-empty-routes-"));
+		const output = join(emptyDir, "routes.d.ts");
+
+		await generateTypes({
+			dir: emptyDir,
+			output,
+		});
+
+		const content = await Bun.file(output).text();
+		expect(content).toContain("export type AutoloadedRoutes = Elysia;");
+		expect(content).not.toContain("export type AutoloadedRoutes = ;");
 	});
 });

--- a/test/treaty.test.ts
+++ b/test/treaty.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from "bun:test";
 import { treaty } from "@elysiajs/eden";
 import { Elysia } from "elysia";
 import { app } from "../example";
-import { autoload } from "../src/index";
 import type { AutoloadedRoutes } from "../example/routes";
+import { autoload } from "../src/index";
 
 describe("Treaty - Basic", () => {
 	it("should work with treaty for index route", async () => {
@@ -275,7 +275,7 @@ describe("Treaty - SDK Pattern", () => {
 		type AppType = typeof app;
 
 		const createSdk = (domain: string | AppType) => {
-			const client = treaty<AppType>(domain as any);
+			const client = treaty<AppType>(domain);
 			return client;
 		};
 


### PR DESCRIPTION
- Make autoload accept no argument by defaulting options to {}.
- Generate valid AutoloadedRoutes when no route files exist by using Elysia.